### PR TITLE
Allow multiple conditional filters on the same field

### DIFF
--- a/datastore/mongo/test.py
+++ b/datastore/mongo/test.py
@@ -37,6 +37,18 @@ class TestMongoDatastore(TestDatastore):
     res = list(ms.query(Query(pk).filter('age','>',30)))
     assert res == [a]
 
+    res = list(ms.query(Query(pk).filter('age','>',30).filter('age','<',30)))
+    assert res == []
+
+    res = list(ms.query(Query(pk).filter('age','=',35)))
+    assert res == [a]
+
+    try:
+      res = list(ms.query(Query(pk).filter('age','>',30).filter('age','=',30)))
+      assert False
+    except ValueError:
+      pass
+
     res = list(ms.query(Query(pk).filter('name','!=','A')))
     assert res == [b]
 


### PR DESCRIPTION
Multiple conditional filters on the same field are currently silently ignored, because the list gets blindly converted to a dict. It should be possible to do something like this:

``` python
store.query(Query().filter('age','>',30).filter('age','<',40))
```
